### PR TITLE
Saving fixed :)

### DIFF
--- a/NppGist/DllExport/NppPlugin.DllExport.targets
+++ b/NppGist/DllExport/NppPlugin.DllExport.targets
@@ -19,6 +19,6 @@
                    FrameworkPath="$(TargetedFrameworkDir);$(TargetFrameworkDirectory)"
                    LibToolPath="$(DevEnvDir)\..\..\VC\bin"
                    LibToolDllPath="$(DevEnvDir)"
-                   SdkPath="$(FrameworkSDKDir)"/>
+                   SdkPath="$(SDK40ToolsPath)"/>
   </Target>
 </Project>

--- a/NppGist/Forms/GuiUtils.cs
+++ b/NppGist/Forms/GuiUtils.cs
@@ -200,10 +200,8 @@ namespace NppGist.Forms
 			else
 			{
 				cmbLanguage.Enabled = false;
-                ///languages/detect? is no longer supported by api. See here https://developer.github.com/v3/gists/
-                //var response = Utils.SendJsonRequest<JsonObject>(string.Format("{0}/languages/detect?name={1}",
-                //Main.GistUrl, HttpUtility.UrlEncode(tbFilename.Text)));
-                cmbLanguage.SelectedItem = "none";
+				//languages/detect? is no longer supported by api. See here https://developer.github.com/v3/gists/
+				cmbLanguage.SelectedItem = "none";
 			}
 		}
 


### PR DESCRIPTION
* updated for vs2015
* deleted one request which no longer supported by api

И спасибо за помощь)
в принципе можно только [эту ветку](https://github.com/ayazzali/NppGist/tree/feature/saving_gists_fixed) смержить - она без обновления на VS2015.
и да [надо добавить в VS "Visual C++"](NotepadPlusPlusPluginPack.Net/documentation/installcpp.png) а то будет ругаться будет про "anci" и "unicode")